### PR TITLE
Fix fetching wrong headings with default outshine base char

### DIFF
--- a/helm-navi.el
+++ b/helm-navi.el
@@ -130,7 +130,9 @@ function to return a regular expression, or
                              ((pred stringp) regexp)
                              ((pred null) (concat "^\\("
                                                   (mapconcat (lambda (s)
-                                                               (s-trim (car s)))
+                                                               (if (string= outshine-regexp-base-char "*")
+                                                                   (replace-regexp-in-string (regexp-quote "*") "\\*" (s-trim (car s)) nil 'literal)
+                                                                 (s-trim (car s))))
                                                              outshine-promotion-headings
                                                              "\\|")
                                                   "\\)"


### PR DESCRIPTION
When enabling a major-mode whose `outshine-regexp-base-char` is the default value `"*"`, `helm-navi-headings` will detect everything that leaves a blank after `comment-start` even if there is no `"*"`.

In the following example both lines are incorrectly detected with `helm-navi-headings` whilst only the first line is detected with `navi-search-and-switch` in major-modes such as python/shell-script:
```python
# * foo
# foo
```

I believe this is due to the unquoted inclusion of the glob pattern `"*"` in the heading-regexp of `helm-navi--get-candidates-in-buffer` function.

These changes seem to fix the issue and only detect the first line in previous example. However, there might be other cleaner ways of  fixing this.

Thanks!