### PR TITLE
Fix fetching wrong headings with default outshine base char

### DIFF
--- a/helm-navi.el
+++ b/helm-navi.el
@@ -130,7 +130,9 @@ function to return a regular expression, or
                              ((pred stringp) regexp)
                              ((pred null) (concat "^\\("
                                                   (mapconcat (lambda (s)
-                                                               (s-trim (car s)))
+                                                               (if (string= outshine-regexp-base-char "*")
+                                                                   (replace-regexp-in-string (regexp-quote "*") "\\*" (s-trim (car s)) nil 'literal)
+                                                                 (s-trim (car s))))
                                                              outshine-promotion-headings
                                                              "\\|")
                                                   "\\)"


### PR DESCRIPTION
Replaces #5, comparing from branch `fix/default-outshine-base-char` instead of `master`. 